### PR TITLE
Add `libqalculate` (Qalculate!) manual references

### DIFF
--- a/website/src/routes/about/+page.svelte
+++ b/website/src/routes/about/+page.svelte
@@ -17,10 +17,10 @@
 </p>
 
 <p>
-	<a href="https://qalculate.github.io/manual/qalculate-definitions-functions.html">Functions</a> • 
-	<a href="https://qalculate.github.io/manual/qalculate-definitions-variables.html">Variables</a> • 
-	<a href="https://qalculate.github.io/manual/qalculate-definitions-units.html">Units</a> • 
-	<a href="https://qalculate.github.io/manual/qalculate-examples.html">Examples</a>
+	<a href="https://qalculate.github.io/manual/qalculate-definitions-functions.html" target="_blank">Functions</a> • 
+	<a href="https://qalculate.github.io/manual/qalculate-definitions-variables.html" target="_blank">Variables</a> • 
+	<a href="https://qalculate.github.io/manual/qalculate-definitions-units.html" target="_blank">Units</a> • 
+	<a href="https://qalculate.github.io/manual/qalculate-examples.html" target="_blank">Examples</a>
 </p>
 
 <h3>Feedback</h3>

--- a/website/src/routes/about/+page.svelte
+++ b/website/src/routes/about/+page.svelte
@@ -16,6 +16,13 @@
 	> library by Hanna Knutsson.
 </p>
 
+<p>
+	<a href="https://qalculate.github.io/manual/qalculate-definitions-functions.html">Functions</a> • 
+	<a href="https://qalculate.github.io/manual/qalculate-definitions-variables.html">Variables</a> • 
+	<a href="https://qalculate.github.io/manual/qalculate-definitions-units.html">Units</a> • 
+	<a href="https://qalculate.github.io/manual/qalculate-examples.html">Examples</a>
+</p>
+
 <h3>Feedback</h3>
 <p>
 	...is welcome 🙂<br />

--- a/website/src/routes/about/+page.svelte
+++ b/website/src/routes/about/+page.svelte
@@ -20,7 +20,7 @@
 	<a href="https://qalculate.github.io/manual/qalculate-definitions-functions.html" target="_blank">Functions</a> • 
 	<a href="https://qalculate.github.io/manual/qalculate-definitions-variables.html" target="_blank">Variables</a> • 
 	<a href="https://qalculate.github.io/manual/qalculate-definitions-units.html" target="_blank">Units</a> • 
-	<a href="https://qalculate.github.io/manual/qalculate-examples.html" target="_blank">Examples</a>
+	<a href="/examples">Examples</a>
 </p>
 
 <h3>Feedback</h3>


### PR DESCRIPTION
This would help users understanding what they can write in the calculator text box.

E.g. now I had to manually find and look up the reference of the `days()` function. Now it would be just two clicks.